### PR TITLE
correctly pulls in tool data from DB

### DIFF
--- a/src/components/AppProvider.js
+++ b/src/components/AppProvider.js
@@ -1,16 +1,39 @@
 import React, { Component } from 'react';
+import { API_BASE_URL } from '../config';
 
-export const AppContext = React.createContext()
+export const AppContext = React.createContext();
 
 class AppProvider extends Component {
-
     state = {
-        error: null
+      error: null,
+      tools: [],
     }
 
+    componentDidMount = () => {
+      fetch(`${API_BASE_URL}/tools`, {
+        method: 'GET',
+        // headers: {
+        //   'content-type': 'application/json',
+        //   'Authorization': `Bearer ${config.API_KEY}`
+        // }
+      })
+        .then((toolsResponse) => {
+          if(!toolsResponse.ok) {
+            return toolsResponse.json().then(error => Promise.reject(error))
+          }
+          return toolsResponse.json()
+        })
+        .then((tools) => {
+          this.setState({tools})
+        })
+        .catch(err => {
+          this.setState({
+            error: err.message
+          });
+        })
+    }
 
     render() {
-        
         return (
             <AppContext.Provider
                 value = {{
@@ -19,7 +42,7 @@ class AppProvider extends Component {
                         // passes state to other components
                     },
                     actions: {
-                        // Functions go here
+                      
                     },
                 }}>    
                 {this.props.children}    

--- a/src/components/ToolCard/ToolCard.js
+++ b/src/components/ToolCard/ToolCard.js
@@ -1,16 +1,17 @@
 import React, {Component} from 'react';
 import '../../assets/css/styles.css'
 
-
 class ToolCard extends Component {
   render() {
-    const { name, availability, imageURL } = this.props
-    const availabilityStatus = availability ? 'Available for check-out' : 'Not available for check-out'
+    const t = this.props
+    const url = `https://res.cloudinary.com/tooltimeshare/image/upload/tools/${t.tool_img_filename}`;
+    // const availabilityStatus = availability ? 'Available for check-out' : 'Not available for check-out'
     return (
       <div className="toolCard">
-        <img alt="tool name" src={imageURL} />
-        <h4>{name}</h4>
-        <p>{availabilityStatus}</p>
+        <img alt={t.tool_img_alt} src={url} />
+        <h4>{t.tool_name}</h4>
+        <p>{t.tool_desc}</p>
+        {/* <p>{availabilityStatus}</p> */}
         <a href="/">Reserve This Item</a>
       </div>
     );

--- a/src/components/ToolCard/ToolCardList.js
+++ b/src/components/ToolCard/ToolCardList.js
@@ -1,13 +1,18 @@
 import React, { Component } from 'react';
 import ToolCard from './ToolCard'
+import { AppContext } from '../AppProvider';
 
 class ToolCardList extends Component {
   render() {
-    const { tools } = this.props
     return (
-      tools.map(tool =>
-        <ToolCard key={tool.id} availability={tool.availability} imageURL={tool.imageURL} name={tool.name} />
-      )
+      <AppContext.Consumer>
+        {value => (
+          value.state.tools.map(tool =>
+            <ToolCard key={tool.id} {...tool} />
+          )
+        )}
+      </AppContext.Consumer>
+      
     );
   }
 }

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  API_BASE_URL: process.env.REACT_APP_API_BASE_URL || `http://localhost:8000/api`,
+}

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -2,33 +2,12 @@ import React, { Component } from 'react';
 import ToolCardList from '../components/ToolCard/ToolCardList';
 import '../assets/css/HomePage.css'
 
-
-
 class HomePage extends Component {
+
     render() {
-        const tools = [
-            {
-                id: '111',
-                name: 'Claw Hammer',
-                imageURL: 'https://images.homedepot-static.com/productImages/c275d0bb-5e98-412c-b1b1-8726fd1f1477/svn/dewalt-claw-hammers-dwht51054-64_400_compressed.jpg',
-                availability: true
-            },
-            {
-                id: '222',
-                name: 'Sledge Hammer',
-                imageURL: 'https://images.homedepot-static.com/productImages/1fdd9918-d45d-4c54-aaa2-fac5965f27ea/svn/stiletto-claw-hammers-tb15mc-64_400_compressed.jpg',
-                availability: false
-            },
-            {
-                id: '333',
-                name: 'MC Hammer',
-                imageURL: 'https://images.homedepot-static.com/productImages/05c3fadf-c695-4742-85c8-7ec5c1d15703/svn/estwing-specialty-hammers-dfh12-64_400_compressed.jpg',
-                availability: true
-            }
-        ]
         return (
             <div className="HomePage">
-                <ToolCardList tools={tools} />
+                <ToolCardList />
             </div>
         )
     }


### PR DESCRIPTION
This branch successfully adds in the get request for the tools.  It adds in a fetch request to the App Provider and puts the tools data into context.  I then wrapped the ToolCardList component with context and passed the data down through props to the ToolCard.

I added in the tool description and the image url from Cloudinary.  There were a few typos in the seeds file for the images that I fixed. If you already seeded your database, you will have to delete the rows and readd them or you will get errors in the console. 

I commented out the availability as this does not yet live in our database or at least the api service for this data is not yet built.