### PR TITLE
Add routing from homepage to tool details

### DIFF
--- a/src/assets/css/styles.css
+++ b/src/assets/css/styles.css
@@ -3,11 +3,9 @@
  ********************************/
 
 
-
-/******************************** 
- * BEGIN Tool Card Styles
- ********************************/
-.tool-card {
+ /* BEGIN Tool Card Styles
+ ------------------------------*/
+ .tool-card {
   box-sizing: border-box;
   border: 1px solid #888;
   background-color: #efefef;
@@ -27,10 +25,20 @@
   background-color: #fff;
   color: #444;
 }
-/******************************** 
- * END Tool Card Styles
- ********************************/
+ /* END Tool Card Styles
+ ------------------------------*/
 
+
+ /* BEGIN Tool Detail Styles
+ ------------------------------*/
+.tool-detail {
+  width: 480px;
+}
+.tool-detail img {
+  max-width: 100%;
+}
+ /* END Tool Detail Styles
+ ------------------------------*/
 
  
 

--- a/src/components/AppRouter.js
+++ b/src/components/AppRouter.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { Route, Switch } from 'react-router-dom';
 import HomePage from '../pages/HomePage';
+import ToolDetail from '../pages/ToolDetail';
 import LoginPage from '../pages/LoginPage';
 import RegisterPage from '../pages/RegisterPage';
 import NotFoundPage from '../pages/NotFoundPage';
@@ -30,6 +31,7 @@ class AppRouter extends Component {
                             path={'/'}
                             component={HomePage}
                         />
+                        <Route path='/tools/:toolId' component={ToolDetail} />
                         <Route 
                             path={'/login'}
                             component={LoginPage}

--- a/src/components/ToolCard/ToolCard.js
+++ b/src/components/ToolCard/ToolCard.js
@@ -1,10 +1,12 @@
 import React, {Component} from 'react';
+import { Link } from 'react-router-dom';
 import '../../assets/css/styles.css'
 
 class ToolCard extends Component {
   render() {
     const t = this.props
     const url = `https://res.cloudinary.com/tooltimeshare/image/upload/tools/${t.tool_img_filename}`;
+    const toolPageLink = `/tools/${t.id}`
     // const availabilityStatus = availability ? 'Available for check-out' : 'Not available for check-out'
     return (
       <div className="tool-card">
@@ -12,7 +14,9 @@ class ToolCard extends Component {
         <h4>{t.tool_name}</h4>
         <p>{t.tool_desc}</p>
         {/* <p>{availabilityStatus}</p> */}
-        <a href="/">Reserve This Item</a>
+        <Link className="whatever" to='/'>Reserve This Item</Link>
+        <br />
+        <Link className="reserve-link" to={toolPageLink}>View Details</Link>              
       </div>
     );
   }

--- a/src/pages/ToolDetail.js
+++ b/src/pages/ToolDetail.js
@@ -1,0 +1,33 @@
+import React, { Component } from 'react'
+import { AppContext } from '../components/AppProvider'
+
+class ToolDetail extends Component {
+  render() {
+    let urlToolId = this.props.match.params.toolId
+    return (
+      <AppContext.Consumer>
+        {value => {
+          const thisTool = value.state.tools.find(tool => {
+            return tool.id.toString() === urlToolId.toString()
+          })
+          if (thisTool) {
+            const url = `https://res.cloudinary.com/tooltimeshare/image/upload/tools/${thisTool.tool_img_filename}`;
+            return (
+              <div className="tool-detail">
+                <img alt={thisTool.tool_img_alt} src={url} />
+                <h4>{thisTool.tool_name}</h4>
+                <p>{thisTool.tool_desc}</p>
+                {/* <p>{availabilityStatus}</p> */}
+                <a href="/">Reserve This Item</a>
+              </div>              
+            )
+          }
+          return <p>Something went wrong...</p>
+        }}
+      </AppContext.Consumer>
+    )
+  }
+}
+
+
+export default ToolDetail;


### PR DESCRIPTION
Clicking 'View Details' from home page navigates to the tool detail page; the correct path shows up in the browser's URL bar. So if a tool's id is 23, clicking 'View Details' for that tool in the home page grid view will navigate the browser to /tools/23.